### PR TITLE
update: give discord title & thumbnail

### DIFF
--- a/.github/workflows/depoly.yml
+++ b/.github/workflows/depoly.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      article-title: ${{ steps.get-title.outputs.title }}
+      thumbnail-url: ${{ steps.get-title.outputs.thumbnail }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -21,6 +24,52 @@ jobs:
 
       - name: Build
         run: hugo --minify
+
+      - name: Get latest article title and thumbnail
+        id: get-title
+        run: |
+          LATEST_POST=$(
+            find content -name "*.md" -type f \
+                 -exec stat --format='%Y %n' {} + 2>/dev/null | \
+            sort -rn | \
+            head -1 | \
+            cut -d' ' -f2- || \
+            echo ""
+          )
+
+          if [ ! -z "$LATEST_POST" ]; then
+            TITLE=$(
+              awk '/^---$/{flag++; next}
+                flag==1 && /^title:/{
+                  gsub(/^title: *["\047]?/, "");
+                  gsub(/["\047]? *$/, "");
+                  print; exit}' "$LATEST_POST" ||
+              basename "$LATEST_POST" .md
+            )
+            echo "title=$TITLE" >> $GITHUB_OUTPUT
+
+            # 記事と同じディレクトリ内の画像ファイルを探す
+            POST_DIR=$(dirname "$LATEST_POST")
+            THUMBNAIL=$(find "$POST_DIR" -maxdepth 1 -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.gif" -o -iname "*.webp" \) | head -1)
+
+            if [ ! -z "$THUMBNAIL" ]; then
+              # public ディレクトリ内の対応する画像パスを構築
+              RELATIVE_PATH=$(echo "$THUMBNAIL" | sed 's|^content/||')
+              PUBLIC_PATH="public/$RELATIVE_PATH"
+              if [ -f "$PUBLIC_PATH" ]; then
+                # GitHub Pages の URL に変換
+                URL_PATH=$(echo "$RELATIVE_PATH" | sed 's| |%20|g')
+                echo "thumbnail=https://hokumedai.github.io/$URL_PATH" >> $GITHUB_OUTPUT
+              else
+                echo "thumbnail=" >> $GITHUB_OUTPUT
+              fi
+            else
+              echo "thumbnail=" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "title=" >> $GITHUB_OUTPUT
+            echo "thumbnail=" >> $GITHUB_OUTPUT
+          fi
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
@@ -45,30 +94,42 @@ jobs:
         if: success()
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          ARTICLE_TITLE: ${{ needs.build.outputs.article-title }}
+          THUMBNAIL_URL: ${{ needs.build.outputs.thumbnail-url }}
         run: |
-          LATEST_POST=$(
-            find content -name "*.md" -type f \
-                 -exec stat --format='%Y %n' {} + 2>/dev/null | \
-            sort -rn | \
-            head -1 | \
-            cut -d' ' -f2- || \
-            echo ""
-          )
-          
-          if [ ! -z "$LATEST_POST" ]; then
-            TITLE=$(\
-              awk '/^---$/{flag++; next} 
-                flag==1 && /^title:/{
-                  gsub(/^title: *["\047]?/, "");
-                  gsub(/["\047]? *$/, "");
-                  print; exit}' "$LATEST_POST" ||
-              basename "$LATEST_POST" .md
-            )
-            MESSAGE="新しい記事「$TITLE」を公開しました！"
+          if [ ! -z "$ARTICLE_TITLE" ]; then
+            MESSAGE="新しい記事「$ARTICLE_TITLE」を公開しました！"
           else
             MESSAGE="ホームページを更新しました！"
           fi
-          
+
+          # Discord Webhook用のJSONペイロードを構築
+          if [ ! -z "$THUMBNAIL_URL" ]; then
+            # サムネイルがある場合はembedを使用
+            PAYLOAD=$(cat <<EOF
+          {
+            "content": "$MESSAGE",
+            "embeds": [{
+              "title": "$ARTICLE_TITLE",
+              "url": "${{ steps.deployment.outputs.page_url }}",
+              "image": {
+                "url": "$THUMBNAIL_URL"
+              },
+              "color": 5814783
+            }]
+          }
+          EOF
+            )
+          else
+            # サムネイルがない場合はシンプルなメッセージ
+            PAYLOAD=$(cat <<EOF
+          {
+            "content": "$MESSAGE\nURLはこちらから↓\n${{ steps.deployment.outputs.page_url }}"
+          }
+          EOF
+            )
+          fi
+
           curl -H "Content-Type: application/json" \
-               -d "{\"content\": \"$MESSAGE\nURLはこちらから↓\n${{ steps.deployment.outputs.page_url }}\"}" \
+               -d "$PAYLOAD" \
                $DISCORD_WEBHOOK


### PR DESCRIPTION
### 主な変更  
デプロイ時に記事のタイトルとサムネイルをdiscordチャンネルに流れるようGitHub Actionsの調整
 
---
### GitHub Actions についての基本の備忘録

#### ビルドプロセス
- /content下のMarkdownファイル等をGitHub上でビルド（Hugo使用）
- ビルド ＝ HTML・CSS・JavaScriptなどの静的ファイルに変換すること
- ビルド成果物は/public下に生成される

#### デプロイプロセス
- /publicフォルダを圧縮してartifactとして保存
- GitHub Pagesサーバーに転送・解凍
- https://hokumedai.github.io/ で一般公開
- デプロイ ＝ artifactの転送から公開までの操作のこと

#### 実行環境
- すべてGitHubのサーバー上で自動実行（GitHub Actions）
- 設定ファイル：/.github/workflows/deploy.yml
- 実行環境：ubuntu-latest（Ubuntu 22.04相当）
- shellコマンド（curl, echo, awk, sed等）が利用可能

#### ジョブ構成
- buildジョブ：ビルド、メタデータ抽出、artifact保存
- deployジョブ：GitHub Pagesへのデプロイ、Discord通知  
