### PR TITLE
fix: add checkout before deploy

### DIFF
--- a/.github/workflows/depoly.yml
+++ b/.github/workflows/depoly.yml
@@ -70,6 +70,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
記事のタイトルが拾われないという不具合
deploy前にcheckoutで解消される（と思われる）