### PR TITLE
fix: #63

### DIFF
--- a/.github/workflows/depoly.yml
+++ b/.github/workflows/depoly.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+          fetch-depth: 0
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2


### PR DESCRIPTION
コミット履歴を1つしかたどらないせいで、複数コミットがプッシュされた際に差分を認識できないようでした
fetch-depth: 0 で全履歴をつかむようにしています